### PR TITLE
BDOG-741: Uplift application.conf for Play 2.6 

### DIFF
--- a/app/uk/gov/hmrc/example/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/example/config/AppConfig.scala
@@ -17,21 +17,17 @@
 package uk.gov.hmrc.example.config
 
 import javax.inject.{Inject, Singleton}
-import play.api.Mode.Mode
-import play.api.{Configuration, Environment}
-import uk.gov.hmrc.play.config.ServicesConfig
+import play.api.Configuration
 
 @Singleton
-class AppConfig @Inject()(val runModeConfiguration: Configuration, environment: Environment) extends ServicesConfig {
+class AppConfig @Inject()(val configuration: Configuration) {
 
-  override protected def mode: Mode = environment.mode
-
-  private def loadConfig(key: String) =
-    runModeConfiguration
-      .getString(key)
+  private def loadConfig(key: String): String =
+    configuration
+      .getOptional[String](key)
       .getOrElse(throw new Exception(s"Missing configuration key: $key"))
 
-  private val contactHost                  = runModeConfiguration.getString(s"contact-frontend.host").getOrElse("")
+  private val contactHost                  = configuration.getOptional[String](s"contact-frontend.host").getOrElse("")
   private val contactFormServiceIdentifier = "MyService"
 
   lazy val assetsPrefix: String     = loadConfig(s"assets.url") + loadConfig(s"assets.version")

--- a/app/uk/gov/hmrc/example/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/example/config/ErrorHandler.scala
@@ -17,18 +17,18 @@
 package uk.gov.hmrc.example.config
 
 import javax.inject.{Inject, Singleton}
-
 import play.api.i18n.MessagesApi
 import play.api.mvc.Request
 import play.twirl.api.Html
+import uk.gov.hmrc.cookiebanner.CookieBanner
 import uk.gov.hmrc.play.bootstrap.http.FrontendErrorHandler
 import uk.gov.hmrc.example.views
 
 @Singleton
-class ErrorHandler @Inject()(val messagesApi: MessagesApi, implicit val appConfig: AppConfig)
+class ErrorHandler @Inject()(val messagesApi: MessagesApi, cookieBanner: CookieBanner, implicit val appConfig: AppConfig)
     extends FrontendErrorHandler {
 
   override def standardErrorTemplate(pageTitle: String, heading: String, message: String)(
     implicit request: Request[_]): Html =
-    views.html.error_template(pageTitle, heading, message)
+    views.html.error_template(pageTitle, heading, message, cookieBanner)
 }

--- a/app/uk/gov/hmrc/example/controllers/HelloWorldController.scala
+++ b/app/uk/gov/hmrc/example/controllers/HelloWorldController.scala
@@ -17,21 +17,19 @@
 package uk.gov.hmrc.example.controllers
 
 import javax.inject.{Inject, Singleton}
-
 import play.api.mvc._
-
-import scala.concurrent.Future
-import play.api.i18n.{I18nSupport, MessagesApi}
-import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import uk.gov.hmrc.cookiebanner.CookieBanner
 import uk.gov.hmrc.example.config.AppConfig
 import uk.gov.hmrc.example.views
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
+import scala.concurrent.Future
 
 @Singleton
-class HelloWorldController @Inject()(val messagesApi: MessagesApi, implicit val appConfig: AppConfig)
-    extends FrontendController
-    with I18nSupport {
+class HelloWorldController @Inject()(val mcc: MessagesControllerComponents, cookieBanner: CookieBanner, implicit val appConfig: AppConfig)
+    extends FrontendController(mcc) {
 
   val helloWorld = Action.async { implicit request =>
-    Future.successful(Ok(views.html.hello_world()))
+    Future.successful(Ok(views.html.hello_world(cookieBanner)))
   }
 }

--- a/app/uk/gov/hmrc/example/views/error_template.scala.html
+++ b/app/uk/gov/hmrc/example/views/error_template.scala.html
@@ -15,7 +15,9 @@
  *@
 
 @import uk.gov.hmrc.example.config.AppConfig
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@import uk.gov.hmrc.cookiebanner.CookieBanner
+
+@(pageTitle: String, heading: String, message: String, cookieBanner: CookieBanner)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @contentHeader = {
   <h1>@heading</h1>
@@ -25,4 +27,4 @@
   <p>@message</p>
 }
 
-@govuk_wrapper(appConfig = appConfig, title = pageTitle, contentHeader = Some(contentHeader), mainContent = mainContent)
+@govuk_wrapper(appConfig = appConfig, title = pageTitle,  cookieBanner = cookieBanner, contentHeader = Some(contentHeader), mainContent = mainContent)

--- a/app/uk/gov/hmrc/example/views/govuk_wrapper.scala.html
+++ b/app/uk/gov/hmrc/example/views/govuk_wrapper.scala.html
@@ -14,11 +14,13 @@
  * limitations under the License.
  *@
 
+@import play.twirl.api.HtmlFormat
 @import uk.gov.hmrc.example.config.AppConfig
-@import uk.gov.hmrc.cookiebanner.CookieBannerStatic
+@import uk.gov.hmrc.cookiebanner.CookieBanner
 
 @(appConfig: AppConfig,
   title: String,
+  cookieBanner: CookieBanner,
   mainClass: Option[String] = None,
   mainDataAttributes: Option[Html] = None,
   bodyClasses: Option[String] = None,
@@ -37,7 +39,7 @@
       linkElem = None,
       headScripts = None)
     <meta name="format-detection" content="telephone=no" />
-    @CookieBannerStatic.cookieBanner
+    @cookieBanner.cookieBanner
 }
 
 @headerNavLinks = {}

--- a/app/uk/gov/hmrc/example/views/hello_world.scala.html
+++ b/app/uk/gov/hmrc/example/views/hello_world.scala.html
@@ -15,8 +15,10 @@
  *@
 
 @import uk.gov.hmrc.example.config.AppConfig
-@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@import uk.gov.hmrc.cookiebanner.CookieBanner
 
-@main_template(title = "Hello from platops-example-frontend-microservice", bodyClasses = None) {
+@(cookieBanner: CookieBanner)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+
+@main_template(title = "Hello from platops-example-frontend-microservice", cookieBanner = cookieBanner, bodyClasses = None) {
     <h1>Hello from pipelined platops-example-frontend-microservice !</h1>
 }

--- a/app/uk/gov/hmrc/example/views/main_template.scala.html
+++ b/app/uk/gov/hmrc/example/views/main_template.scala.html
@@ -15,12 +15,15 @@
  *@
 
 @import uk.gov.hmrc.example.config.AppConfig
+@import uk.gov.hmrc.cookiebanner.CookieBanner
+
 @(title: String,
   sidebarLinks: Option[Html] = None,
   contentHeader: Option[Html] = None,
   bodyClasses: Option[String] = None,
   mainClass: Option[String] = None,
-  scriptElem: Option[Html] = None)(mainContent: Html)(implicit request : Request[_], messages: Messages, appConfig: AppConfig)
+  scriptElem: Option[Html] = None,
+  cookieBanner: CookieBanner)(mainContent: Html)(implicit request : Request[_], messages: Messages, appConfig: AppConfig)
 
 @import uk.gov.hmrc.play.views.html.layouts
 
@@ -36,6 +39,7 @@
 
 @govuk_wrapper(appConfig = appConfig,
                title = title,
+               cookieBanner = cookieBanner,
                mainClass = mainClass,
                bodyClasses = bodyClasses,
                sidebar = sidebar,

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     majorVersion                                  := 2,
     libraryDependencies                           ++= AppDependencies.compile ++ AppDependencies.test,
-    evictionWarningOptions in update              := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
-    routesGenerator                               := StaticRoutesGenerator
+    evictionWarningOptions in update              := EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
   )
   .settings(publishingSettings: _*)
   .settings(scoverageSettings: _*)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,3 @@
 # microservice specific routes
 
-GET        /hello-world             @uk.gov.hmrc.example.controllers.HelloWorldController.helloWorld
+GET        /hello-world             uk.gov.hmrc.example.controllers.HelloWorldController.helloWorld

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -53,7 +53,7 @@ play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' 
 # Not set here so that MDTP frontends share the same secret key in the local environment
 # (see common.conf in frontend-bootstrap).
 # In server environments the secret comes from app-config-common
-# play.crypto.secret="6fX5H9isJW9gHLqKgRBsnL3ClpJljSqshvBo2UosOP3mhjXGDLZk3uEVdkxlRvPF"
+# play.http.secret.key="6fX5H9isJW9gHLqKgRBsnL3ClpJljSqshvBo2UosOP3mhjXGDLZk3uEVdkxlRvPF"
 
 microservice {
     metrics {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -15,7 +15,7 @@
 include "frontend.conf"
 
 appName="platops-example-frontend-microservice"
-application.router=prod.Routes
+play.http.router=prod.Routes
 
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,6 +1,6 @@
 # Add all the application routes to the app.routes file
-->         /platops-example-frontend-microservice                   app.Routes
-->         /                          health.Routes
-->     	   /template                  template.Routes
+->         /platops-example-frontend-microservice        app.Routes
+->         /                                             health.Routes
+->     	   /template                                     template.Routes
 
-GET        /admin/metrics             @com.kenshoo.play.metrics.MetricsController.metrics
+GET        /admin/metrics                                com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,19 +3,20 @@ import sbt._
 
 object AppDependencies {
   val compile = Seq(
-    "uk.gov.hmrc"       %% "govuk-template"    % "5.28.0-play-25",
-    "uk.gov.hmrc"       %% "play-ui"           % "7.32.0-play-25",
-    "uk.gov.hmrc"       %% "bootstrap-play-25" % "5.2.0"
+    "uk.gov.hmrc"       %% "govuk-template"    % "5.54.0-play-26",
+    "uk.gov.hmrc"       %% "play-ui"           % "8.8.0-play-26",
+    "uk.gov.hmrc"       %% "bootstrap-play-26" % "1.7.0"
   )
 
   val test = Seq(
-    "org.scalatest"           %% "scalatest"                % "3.0.5"             % "test",
-    "org.jsoup"               % "jsoup"                     % "1.10.2"            % "test",
-    "com.typesafe.play"       %% "play-test"                % PlayVersion.current % "test",
-    "org.seleniumhq.selenium" % "selenium-java"             % "2.53.1"            % "test",
-    "org.seleniumhq.selenium" % "selenium-htmlunit-driver"  % "2.52.0"            % "test",
+    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.7.0"             % Test classifier "tests",
+    "org.scalatest"           %% "scalatest"                % "3.0.8"             % Test,
+    "org.scalatestplus.play"  %% "scalatestplus-play"       % "3.1.2"             % "test, it",
     "org.pegdown"             % "pegdown"                   % "1.6.0"             % "test, it",
-    "org.scalatestplus.play"  %% "scalatestplus-play"       % "2.0.1"             % "test, it",
-    "uk.gov.hmrc"             %% "service-integration-test" % "0.5.0-play-25"     % "test, it"
+    "com.typesafe.play"       %% "play-test"                % PlayVersion.current % Test,
+    "org.jsoup"               % "jsoup"                     % "1.10.2"            % Test,
+    "org.seleniumhq.selenium" % "selenium-java"             % "2.53.1"            % Test,
+    "org.seleniumhq.selenium" % "selenium-htmlunit-driver"  % "2.52.0"            % Test,
+    "uk.gov.hmrc"             %% "service-integration-test" % "0.10.0-play-26"    % "test, it"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,16 +9,16 @@ resolvers += Resolver.jcenterRepo
 
 resolvers += DefaultMavenRepository
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")

--- a/test/uk/gov/hmrc/example/controllers/HelloWorldControllerSpec.scala
+++ b/test/uk/gov/hmrc/example/controllers/HelloWorldControllerSpec.scala
@@ -16,25 +16,27 @@
 
 package uk.gov.hmrc.example.controllers
 
+
 import org.scalatest.{Matchers, WordSpec}
-import org.scalatestplus.play.OneAppPerSuite
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
-import play.api.i18n.{DefaultLangs, DefaultMessagesApi}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Configuration, Environment}
+import uk.gov.hmrc.cookiebanner.CookieBanner
 import uk.gov.hmrc.example.config.AppConfig
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
-class HelloWorldControllerSpec extends WordSpec with Matchers with OneAppPerSuite {
-  val fakeRequest = FakeRequest("GET", "/")
-
-  val env           = Environment.simple()
-  val configuration = Configuration.load(env)
-
-  val messageApi = new DefaultMessagesApi(env, configuration, new DefaultLangs(configuration))
-  val appConfig  = new AppConfig(configuration, env)
-
-  val controller = new HelloWorldController(messageApi, appConfig)
+class HelloWorldControllerSpec extends WordSpec with Matchers with GuiceOneAppPerSuite {
+  private val fakeRequest = FakeRequest("GET", "/")
+  private val env = Environment.simple()
+  private val configuration = Configuration.load(env)
+  private val mcc = stubMessagesControllerComponents()
+  private val appConfig  = new AppConfig(configuration)
+  private val httpClient = app.injector.instanceOf[HttpClient]
+  private val cookieBanner = new CookieBanner(httpClient, configuration)
+  private val controller = new HelloWorldController(mcc, cookieBanner, appConfig)
 
   "GET /" should {
     "return 200" in {


### PR DESCRIPTION
Firstly had to uplift this project to Play 2.6.

Then updated application.conf in accordance with the proposal for how init-service should generate config for frontend services going forwards.